### PR TITLE
Changes to format

### DIFF
--- a/R/azmet_daily_data_download.R
+++ b/R/azmet_daily_data_download.R
@@ -202,7 +202,8 @@ azmet_daily_data_download <- function(stn_list, stn_name) {
         )
       ) |>
       select(-starts_with("temp_soil_"))
-  } else { #if there's no pre-2002 data
+  } else {
+    #if there's no pre-2002 data
     data_pre_2002 <- tibble::tibble()
   }
 
@@ -295,15 +296,15 @@ azmet_daily_data_download <- function(stn_list, stn_name) {
   # that may be missing in the downloaded original data
   obs_dyly <- obs_dyly |>
     dplyr::mutate(
-      obs_year = lubridate::year(obs_datetime),
-      obs_doy = lubridate::yday(obs_datetime)
+      obs_year = strftime(obs_datetime, "%Y", tz = tz(obs_datetime)),
+      obs_doy = strftime(obs_datetime, "%j", tz = tz(obs_datetime))
     )
 
   # Populate station ID in the format of "az01"
   # TODO: ask Matt Harmon about these variables
   station_number <- formatC(stn_info$stn_no[1], flag = 0, width = 2)
   station_id <- paste0("az", station_number)
-  
+
   obs_dyly <- obs_dyly |>
     dplyr::mutate(
       station_number = station_number,
@@ -313,12 +314,12 @@ azmet_daily_data_download <- function(stn_list, stn_name) {
   # Populate defaults for some missing/empty columns
   obs_dyly <- obs_dyly |>
     dplyr::mutate(
-      obs_hour = 0,
+      obs_hour = "0000",
       obs_seconds = 0,
       obs_version = 1,
       obs_creation_reason = "legacy data transcription",
       obs_needs_review = 0,
-      obs_prg_code = 0428, #"program code"—used to be size of program running on data logger, now just a 4 digit code.
+      obs_prg_code = "0428", #"program code"—used to be size of program running on data logger, now just a 4 digit code.
       obs_dyly_bat_volt_max = NA_real_,
       obs_dyly_bat_volt_min = NA_real_,
       obs_dyly_bat_volt_mean = NA_real_,

--- a/R/azmet_hourly_data_download.R
+++ b/R/azmet_hourly_data_download.R
@@ -275,7 +275,7 @@ azmet_hourly_data_download <- function(stn_list, stn_name) {
       obs_version = 1,
       obs_creation_reason = "legacy data transcription",
       obs_needs_review = 0,
-      obs_prg_code = 0428, #"program code"—used to be size of program running on data logger, now just a 4 digit code.
+      obs_prg_code = "0428", #"program code"—used to be size of program running on data logger, now just a 4 digit code.
       obs_hrly_wind_2min_vector_dir = NA_real_,
       obs_hrly_wind_2min_spd_max = NA_real_,
       obs_hrly_wind_2min_spd_mean = NA_real_,

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,11 +24,11 @@ mps_to_mph <- function(x) {
 use_24_datetime <- function(x) {
   if_else(
     strftime(x, "%T", tz = tz(x)) == "00:00:00",
-    glue::glue("{strftime(x - days(1), tz = tz(x), format = '%F')} 24:00:00"),
+    glue::glue("{strftime(x - days(1), tz = tz(x), format = '%F')} 23:59:59"),
     glue::glue("{strftime(x, tz = tz(x), format = '%F %T')}")
   )
 }
-# use_24_datetime(midnight) == "2024-12-31 24:00:00"
+# use_24_datetime(midnight) == "2024-12-31 23:59:59"
 # use_24_datetime(ymd_hms("2024-04-28 01:00:00")) == "2024-04-28 01:00:00"
 
 use_24_yday <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,8 +16,8 @@ mps_to_mph <- function(x) {
   x * 2.2369362920544
 }
 
-# Helpers to deal with AZMET database using 24:00:00 for midnight instead of
-# 00:00:00 like R.
+# Helpers to deal with AZMET database using 2400 and 23:59:059 for midnight
+# instead of ISO standard 00:00:00 like R.
 
 # midnight <- ymd_hms("2024-12-31 24:00:00")
 
@@ -25,7 +25,7 @@ use_24_datetime <- function(x) {
   if_else(
     strftime(x, "%T", tz = tz(x)) == "00:00:00",
     glue::glue("{strftime(x - days(1), tz = tz(x), format = '%F')} 23:59:59"),
-    glue::glue("{strftime(x, tz = tz(x), format = '%F %T')}")
+    strftime(x, tz = tz(x), format = '%F %T')
   )
 }
 # use_24_datetime(midnight) == "2024-12-31 23:59:59"
@@ -34,24 +34,28 @@ use_24_datetime <- function(x) {
 use_24_yday <- function(x) {
   if_else(
     strftime(x, "%T", tz = tz(x)) == "00:00:00",
-    lubridate::yday(x - lubridate::days(1)), #deals with leap years and returns either 365 or 366
-    lubridate::yday(x)
+    strftime(x - lubridate::days(1), "%j", tz = tz(x)), #deals with leap years and returns either 365 or 366
+    strftime(x, "%j", tz = tz(x))
   )
 }
 # use_24_yday(midnight) != yday(midnight)
 # use_24_yday(ymd_hms("2024-04-28 24:00:00")) == yday(ymd("2024-04-28"))
 
 use_24_hour <- function(x) {
-  if_else(strftime(x, "%T", tz = tz(x)) == "00:00:00", 24L, lubridate::hour(x))
+  if_else(
+    strftime(x, "%T", tz = tz(x)) == "00:00:00",
+    "2400",
+    strftime(x, "%H00", tz = tz(x))
+  )
 }
-# use_24_hour(midnight) == 24
-# use_24_hour(ymd_hms("2024-04-28 11:00:00")) == 11
+# use_24_hour(midnight) == "2400"
+# use_24_hour(ymd_hms("2024-04-28 02:00:00")) == "0200"
 
 use_24_year <- function(x) {
   if_else(
     strftime(x, tz = tz(x), format = "%m-%d %T") == "01-01 00:00:00",
-    lubridate::year(x - lubridate::days(1)),
-    lubridate::year(x)
+    strftime(x - lubridate::days(1), "%Y", tz = tz(x)),
+    strftime(x, "%Y", tz = tz(x))
   )
 }
 # use_24_year(midnight) != year(midnight)


### PR DESCRIPTION
From Matt Harmon's feedback

- Changes `obs_doy` to have leading digits, e.g. 001 for Jan 1
- Changes `obs_hour` to be 4 digits, e.g. 0200 or 2400
- Uses `strftime()` instead of `lubridate` in some places since the outputs can be character anyway