### PR TITLE
daily RH rounding to `digits = 0`

### DIFF
--- a/R/azmet_daily_data_download.R
+++ b/R/azmet_daily_data_download.R
@@ -536,7 +536,6 @@ azmet_daily_data_download <- function(stn_list, stn_name, years = NULL) {
       dplyr::across(
         c(
           obs_dyly_precip_total,
-          dplyr::starts_with("obs_dyly_relative_humidity_"),
           dplyr::starts_with("obs_dyly_temp_air_"),
           dplyr::starts_with("obs_dyly_temp_soil_"),
           dplyr::starts_with("obs_dyly_wind_spd_"),
@@ -553,6 +552,7 @@ azmet_daily_data_download <- function(stn_list, stn_name, years = NULL) {
       ),
       dplyr::across(
         c(
+          dplyr::starts_with("obs_dyly_relative_humidity_"),
           dplyr::starts_with("obs_dyly_wind_vector_dir"),
           obs_dyly_wind_2min_vector_dir,
           obs_dyly_wind_2min_timestamp


### PR DESCRIPTION
This is to make RH rounding the same as that in the hourly legacy data download function (i.e., `digits = 0`). Looking at the API 2020 data, it seems Matt (Harmon) re-checks the rounding, so this isn't an issue with the legacy data we already shipped.